### PR TITLE
WS-6392 Removed Nonexistent Links and Edited Some Other Links

### DIFF
--- a/docs/Selectors.md
+++ b/docs/Selectors.md
@@ -16,7 +16,6 @@ selected element. These selectors can be used as data extraction selectors:
 
  * [Text selector] [text-selector]
  * [Link selector] [link-selector]
- * [Link popup selector] [link-popup-selector]
  * [Image selector] [image-selector]
  * [Table selector] [table-selector]
  * [Element attribute selector] [element-attribute-selector]
@@ -34,7 +33,6 @@ selectors then these child *Link selectors* would be used for further page
 navigation. These are currently available *Link selectors*:
 
  * [Link selector] [link-selector]
- * [Link popup selector] [link-popup-selector]
 
 ### Element selectors
 
@@ -115,9 +113,8 @@ selectors on [CSS selector][css-selectors] page.
 
  [text-selector]: Selectors/Text%20selector.md
  [link-selector]: Selectors/Link%20Selector.md
- [link-popup-selector]: Selectors/Link%20Popup%20Selector.md
  [image-selector]: Selectors/Image%20selector.md
- [element-attribute-selector]: Selectors/Table%20selector.md
+ [element-attribute-selector]: Selectors/Element%20attribute%20selector.md
  [table-selector]: Selectors/Table%20selector.md
  [grouped-selector]: Selectors/Grouped%20selector.md
  [html-selector]: Selectors/HTML%20selector.md

--- a/docs/Selectors/Element click selector.md
+++ b/docs/Selectors/Element click selector.md
@@ -101,9 +101,6 @@ and during the clicking process, resulting in duplicate or unusable row of data.
 
 ## Related videos
 
-* [How to scrape products using "Load More" button]
-* [How to set up pagination with page numbers using Element Click selector]
-* [How to set up pagination with "Next" button using Element Click selector]
 * [How to iterate through item drop-down variations]
 * [How to iterate through item button variations]
 * [How to iterate through two or more item variation selects]
@@ -112,12 +109,6 @@ and during the clicking process, resulting in duplicate or unusable row of data.
  [image-click-once]: ../images/selectors/element-click/click-once.png?raw=true
  [element-selector]: Element%20selector.md
  [css-selector]: ../CSS%20selector.md
-[How to scrape products using "Load More" button]:
-https://www.webscraper.io/how-to-video/load-more-button
-[How to set up pagination with page numbers using Element Click selector]:
-https://www.webscraper.io/how-to-video/element-click-pagination-buttons
-[How to set up pagination with "Next" button using Element Click selector]:
-https://www.webscraper.io/how-to-video/element-click-pagination-next
 [How to iterate through item drop-down variations]:
 https://www.webscraper.io/how-to-video/dropdown-variation
 [How to iterate through item button variations]:

--- a/docs/Selectors/Image selector.md
+++ b/docs/Selectors/Image selector.md
@@ -26,7 +26,7 @@ required in order for script to work. Images are renamed to
 1. Download and install python 3.x from here:
 [https://www.python.org/downloads/](https://www.python.org/downloads/)
 2. Download image downloader script from here:
-[https://github.com/webscraperio/image-downloader][image-downloader]
+[https://github.com/webscraperio/image-downloader/tags][image-downloader]
 3. Scrape the target site and export data in CSV format
 4. Drag and drop the CSV file on top of the `image-downloader.py`
 ![Fig. 1: windows image download][windows-image-download-script]
@@ -35,7 +35,7 @@ required in order for script to work. Images are renamed to
 
 1. Install python if necessary through your package manager. Most likely you already have it pre-installed.
 2. Download image downloader script from here:
-[https://github.com/webscraperio/image-downloader][image-downloader]
+[https://github.com/webscraperio/image-downloader/tags][image-downloader]
 3. Move `image-downloader.py` to `Downloads` directory
 4. Scrape the target site and export data in CSV format
 5. Save the CSV file in `Downloads` directory
@@ -55,4 +55,4 @@ required in order for script to work. Images are renamed to
  [css-selector]: ../CSS%20selector.md
  [windows-image-download-script]: ../images/selectors/image/win-image-downloader.gif?raw=true
  [osx-image-download-script]: ../images/selectors/image/osx-image-downloader.gif?raw=true
- [image-downloader]: https://github.com/webscraperio/image-downloader/releases
+ [image-downloader]: https://github.com/webscraperio/image-downloader/tags

--- a/docs/Selectors/Link selector.md
+++ b/docs/Selectors/Link selector.md
@@ -39,16 +39,8 @@ selector.
 
 ![Fig. 1: Multiple link selectors for category navigation][multiple-level-link-selectors]
 
-## Related videos
-
-* [How to set up pagination with page numbers using Link selector]
-* [How to set up pagination with "Next" button using Link selector]
 
  [multiple-level-link-selectors]: ../images/selectors/link/multiple-level-link-selectors.png?raw=true
  [element-click]: Element%20click%20selector.md
  [css-selector]: ../CSS%20selector.md
-[How to set up pagination with page numbers using Link selector]:
-https://www.webscraper.io/how-to-video/link-button-pagination
-[How to set up pagination with "Next" button using Link selector]:
-https://www.webscraper.io/how-to-video/link-button-pagination-next
 [pagination-selector]: Pagination%20selector.md


### PR DESCRIPTION
Removed links to other documentation pages and to /how-to-video pages that had been removed from webscraper.io previously; also edited an /image-download GitHub link.